### PR TITLE
fix!: adding tokenEndpoint as configurable

### DIFF
--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -40,7 +40,8 @@ public final class AppAuthSession: LoginSession {
         
         let config = OIDServiceConfiguration(
             authorizationEndpoint: configuration.authorizationEndpoint,
-            tokenEndpoint: URL(string: "https://oidc.integration.account.gov.uk/token")!)
+            tokenEndpoint: configuration.tokenEndPoint
+        )
         
         let request = OIDAuthorizationRequest(
             configuration: config,
@@ -54,6 +55,7 @@ public final class AppAuthSession: LoginSession {
                 "ui_locales": configuration.locale.rawValue
             ]
         )
+        
         self.state = request.state
         
         let agent = OIDExternalUserAgentIOS(
@@ -62,7 +64,7 @@ public final class AppAuthSession: LoginSession {
         )
         
         flow = OIDAuthorizationService.present(request,
-                                                   externalUserAgent: agent!) { [unowned self] response, error in
+                                               externalUserAgent: agent!) { [unowned self] response, error in
             self.authorizationCode = response?.authorizationCode
             self.stateReponse = response?.state
             self.error = error

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -40,7 +40,7 @@ public final class AppAuthSession: LoginSession {
         
         let config = OIDServiceConfiguration(
             authorizationEndpoint: configuration.authorizationEndpoint,
-            tokenEndpoint: configuration.tokenEndPoint
+            tokenEndpoint: configuration.tokenEndpoint
         )
         
         let request = OIDAuthorizationRequest(

--- a/Sources/Authentication/LoginSessionConfiguration.swift
+++ b/Sources/Authentication/LoginSessionConfiguration.swift
@@ -37,7 +37,7 @@ public struct LoginSessionConfiguration {
                 responseType: ResponseType = .code,
                 scopes: [Scope] = [.openid, .email, .phone, .offline_access],
                 clientID: String,
-                prefersEphemeralWebSession: Bool = false,
+                prefersEphemeralWebSession: Bool = true,
                 redirectURI: String,
                 nonce: String = UUID().uuidString,
                 viewThroughRate: String = "[Cl.Cm.P0]",

--- a/Sources/Authentication/LoginSessionConfiguration.swift
+++ b/Sources/Authentication/LoginSessionConfiguration.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public struct LoginSessionConfiguration {
     let authorizationEndpoint: URL
-    let tokenEndPoint: URL
+    let tokenEndpoint: URL
     let responseType: ResponseType
     let scopes: [Scope]
     
@@ -39,11 +39,11 @@ public struct LoginSessionConfiguration {
                 clientID: String,
                 prefersEphemeralWebSession: Bool = false,
                 redirectURI: String,
-                nonce: String,
+                nonce: String = UUID().uuidString,
                 viewThroughRate: String = "[Cl.Cm.P0]",
                 locale: UILocale = .en) {
         self.authorizationEndpoint = authorizationEndpoint
-        self.tokenEndPoint = tokenEndpoint
+        self.tokenEndpoint = tokenEndpoint
         self.responseType = responseType
         self.scopes = scopes
         self.clientID = clientID

--- a/Sources/Authentication/LoginSessionConfiguration.swift
+++ b/Sources/Authentication/LoginSessionConfiguration.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public struct LoginSessionConfiguration {
     let authorizationEndpoint: URL
+    let tokenEndPoint: URL
     let responseType: ResponseType
     let scopes: [Scope]
     
@@ -32,15 +33,17 @@ public struct LoginSessionConfiguration {
     }
     
     public init(authorizationEndpoint: URL,
-                responseType: ResponseType,
-                scopes: [Scope],
+                tokenEndpoint: URL,
+                responseType: ResponseType = .code,
+                scopes: [Scope] = [.openid, .email, .phone, .offline_access],
                 clientID: String,
-                prefersEphemeralWebSession: Bool,
+                prefersEphemeralWebSession: Bool = false,
                 redirectURI: String,
                 nonce: String,
-                viewThroughRate: String,
-                locale: UILocale) {
+                viewThroughRate: String = "[Cl.Cm.P0]",
+                locale: UILocale = .en) {
         self.authorizationEndpoint = authorizationEndpoint
+        self.tokenEndPoint = tokenEndpoint
         self.responseType = responseType
         self.scopes = scopes
         self.clientID = clientID

--- a/Tests/AuthenticationTests/AppAuthSessionTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionTests.swift
@@ -69,6 +69,7 @@ extension AppAuthSessionTests {
 
 extension LoginSessionConfiguration {
     static let mock = LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com")!,
+                                                tokenEndpoint: URL(string: "https://www.google.com/token")!,
                                                 responseType: .code,
                                                 scopes: [.email, .offline_access, .phone, .openid],
                                                 clientID: "1234",

--- a/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
+++ b/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
@@ -2,28 +2,28 @@
 import XCTest
 
 final class LoginSessionConfigurationTests: XCTestCase {
-
+    
     var sut: LoginSessionConfiguration!
+    
+    override func setUp() {
+        super.setUp()
+        sut = LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com")!,
+                                        tokenEndpoint: URL(string: "https://www.google.com/token")!,
+                                        responseType: .code,
+                                        scopes: [.email],
+                                        clientID: "1234",
+                                        prefersEphemeralWebSession: true,
+                                        redirectURI: "https://www.google.com/redirect",
+                                        nonce: "1234",
+                                        viewThroughRate: "1",
+                                        locale: .en)
+    }
+    
+    override func tearDown() {
+        sut = nil
         
-        override func setUp() {
-            super.setUp()
-            sut = .init(LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com")!,
-                                                  tokenEndpoint: URL(string: "https://www.google.com/token")!,
-                                                  responseType: .code,
-                                                  scopes: [.email],
-                                                  clientID: "1234",
-                                                  prefersEphemeralWebSession: true,
-                                                  redirectURI: "https://www.google.com",
-                                                  nonce: "1234",
-                                                  viewThroughRate: "1",
-                                                  locale: .en))
-        }
-        
-        override func tearDown() {
-            sut = nil
-            
-            super.tearDown()
-        }
+        super.tearDown()
+    }
 }
 
 extension LoginSessionConfigurationTests {
@@ -32,15 +32,31 @@ extension LoginSessionConfigurationTests {
     }
     
     func testSUTHasTokenURL() {
-        XCTAssertEqual(sut.tokenEndPoint, URL(string: "https://www.google.com/token"))
+        XCTAssertEqual(sut.tokenEndpoint, URL(string: "https://www.google.com/token"))
     }
     
     func testResponseType() {
         XCTAssertEqual(sut.responseType, .code)
     }
     
+    func testDefaultResponseType() {
+        sut = LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com")!,
+                                        tokenEndpoint: URL(string: "https://www.google.com/token")!,
+                                        clientID: "1234",
+                                        redirectURI: "https://www.google.com/redirect")
+        XCTAssertEqual(sut.responseType, .code)
+    }
+    
     func testScope() {
         XCTAssertEqual(sut.scopes, [.email])
+    }
+    
+    func testDefaultScope() {
+        sut = LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com")!,
+                                        tokenEndpoint: URL(string: "https://www.google.com/token")!,
+                                        clientID: "1234",
+                                        redirectURI: "https://www.google.com/redirect")
+        XCTAssertEqual(sut.scopes, [.openid, .email, .phone, .offline_access])
     }
     
     func testClientID() {
@@ -51,8 +67,16 @@ extension LoginSessionConfigurationTests {
         XCTAssertTrue(sut.prefersEphemeralWebSession)
     }
     
+    func testDefaultPrefersEphemeralWebSession() {
+        sut = LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com")!,
+                                        tokenEndpoint: URL(string: "https://www.google.com/token")!,
+                                        clientID: "1234",
+                                        redirectURI: "https://www.google.com/redirect")
+        XCTAssertFalse(sut.prefersEphemeralWebSession)
+    }
+    
     func testRedirectURI() {
-        XCTAssertEqual(sut.redirectURI, "https://www.google.com")
+        XCTAssertEqual(sut.redirectURI, "https://www.google.com/redirect")
     }
     
     func testNonce() {
@@ -63,7 +87,17 @@ extension LoginSessionConfigurationTests {
         XCTAssertEqual(sut.viewThroughRate, "1")
     }
     
+    func testDefaultViewThroughRate() {
+        sut = LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com")!,
+                                        tokenEndpoint: URL(string: "https://www.google.com/token")!,
+                                        clientID: "1234",
+                                        redirectURI: "https://www.google.com/redirect")
+        XCTAssertEqual(sut.viewThroughRate, "[Cl.Cm.P0]")
+    }
+    
     func testLocale() {
         XCTAssertEqual(sut.locale, .en)
     }
+    
+    
 }

--- a/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
+++ b/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
@@ -7,9 +7,8 @@ final class LoginSessionConfigurationTests: XCTestCase {
         
         override func setUp() {
             super.setUp()
-            let url = URL(string: "https://www.google.com")!
-
-            sut = .init(LoginSessionConfiguration(authorizationEndpoint: url,
+            sut = .init(LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com")!,
+                                                  tokenEndpoint: URL(string: "https://www.google.com/token")!,
                                                   responseType: .code,
                                                   scopes: [.email],
                                                   clientID: "1234",
@@ -30,6 +29,10 @@ final class LoginSessionConfigurationTests: XCTestCase {
 extension LoginSessionConfigurationTests {
     func testSUTHasAuthorizationURL() {
         XCTAssertEqual(sut.authorizationEndpoint, URL(string: "https://www.google.com"))
+    }
+    
+    func testSUTHasTokenURL() {
+        XCTAssertEqual(sut.tokenEndPoint, URL(string: "https://www.google.com/token"))
     }
     
     func testResponseType() {

--- a/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
+++ b/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
@@ -39,24 +39,8 @@ extension LoginSessionConfigurationTests {
         XCTAssertEqual(sut.responseType, .code)
     }
     
-    func testDefaultResponseType() {
-        sut = LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com")!,
-                                        tokenEndpoint: URL(string: "https://www.google.com/token")!,
-                                        clientID: "1234",
-                                        redirectURI: "https://www.google.com/redirect")
-        XCTAssertEqual(sut.responseType, .code)
-    }
-    
     func testScope() {
         XCTAssertEqual(sut.scopes, [.email])
-    }
-    
-    func testDefaultScope() {
-        sut = LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com")!,
-                                        tokenEndpoint: URL(string: "https://www.google.com/token")!,
-                                        clientID: "1234",
-                                        redirectURI: "https://www.google.com/redirect")
-        XCTAssertEqual(sut.scopes, [.openid, .email, .phone, .offline_access])
     }
     
     func testClientID() {
@@ -65,14 +49,6 @@ extension LoginSessionConfigurationTests {
     
     func testPrefersEphemeralWebSession() {
         XCTAssertTrue(sut.prefersEphemeralWebSession)
-    }
-    
-    func testDefaultPrefersEphemeralWebSession() {
-        sut = LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com")!,
-                                        tokenEndpoint: URL(string: "https://www.google.com/token")!,
-                                        clientID: "1234",
-                                        redirectURI: "https://www.google.com/redirect")
-        XCTAssertFalse(sut.prefersEphemeralWebSession)
     }
     
     func testRedirectURI() {
@@ -87,17 +63,18 @@ extension LoginSessionConfigurationTests {
         XCTAssertEqual(sut.viewThroughRate, "1")
     }
     
-    func testDefaultViewThroughRate() {
-        sut = LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com")!,
-                                        tokenEndpoint: URL(string: "https://www.google.com/token")!,
-                                        clientID: "1234",
-                                        redirectURI: "https://www.google.com/redirect")
-        XCTAssertEqual(sut.viewThroughRate, "[Cl.Cm.P0]")
-    }
-    
     func testLocale() {
         XCTAssertEqual(sut.locale, .en)
     }
     
-    
+    func testDefaultValues() {
+        sut = LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com")!,
+                                        tokenEndpoint: URL(string: "https://www.google.com/token")!,
+                                        clientID: "1234",
+                                        redirectURI: "https://www.google.com/redirect")
+        XCTAssertEqual(sut.responseType, .code)
+        XCTAssertEqual(sut.scopes, [.openid, .email, .phone, .offline_access])
+        XCTAssertTrue(sut.prefersEphemeralWebSession)
+        XCTAssertEqual(sut.viewThroughRate, "[Cl.Cm.P0]")
+    }
 }


### PR DESCRIPTION
# fix: adding tokenEndpoint as configurable
# DCMAW-6241: Initiate in-app browser and call /authorize URL

Adding tokenEndpoint as a configurable property on LoginSessionConfiguration, adding unit test

# Checklist

## Before raising your pull request:
- [ ] Update the documentation to reflect your changes
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?~
    ~- [ ] Checked dynamic type sizes are applied~
    ~- [ ] Checked VoiceOver can navigate your new code~
    ~- [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
