### PR TITLE
fix: making LoginSessionConfiguration properties public

### DIFF
--- a/Sources/Authentication/LoginSessionConfiguration.swift
+++ b/Sources/Authentication/LoginSessionConfiguration.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 public struct LoginSessionConfiguration {
-    let authorizationEndpoint: URL
-    let tokenEndpoint: URL
-    let responseType: ResponseType
-    let scopes: [Scope]
+    public let authorizationEndpoint: URL
+    public let tokenEndpoint: URL
+    public let responseType: ResponseType
+    public let scopes: [Scope]
     
-    let clientID: String
+    public let clientID: String
     
-    let prefersEphemeralWebSession: Bool
+    public let prefersEphemeralWebSession: Bool
     
-    let redirectURI: String
+    public let redirectURI: String
     
-    let nonce: String
-    let viewThroughRate: String
-    let locale: UILocale
+    public let nonce: String
+    public let viewThroughRate: String
+    public let locale: UILocale
     
     public enum ResponseType: String {
         case code


### PR DESCRIPTION
# DCMAW-7207: Initiate login (build)

This PR enables us to stop using `@testable import` in our project code for testing instance properties

# Checklist

## Before raising your pull request:
~- [ ] Update the documentation to reflect your changes~
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
