### PR TITLE
fix!: removing nonce from session configuration properties

### DIFF
--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -51,7 +51,6 @@ public final class AppAuthSession: LoginSession {
             responseType: OIDResponseTypeCode,
             additionalParameters: [
                 "vtr": configuration.viewThroughRate,
-                "nonce": configuration.nonce,
                 "ui_locales": configuration.locale.rawValue
             ]
         )

--- a/Sources/Authentication/Custom/CustomAuthSession.swift
+++ b/Sources/Authentication/Custom/CustomAuthSession.swift
@@ -10,6 +10,7 @@ public final class CustomAuthSession: NSObject, LoginSession {
     private let context: UIWindow
     private var session: ASWebAuthenticationSession?
     private(set) var state: String?
+    private let nonce: String
     
     private let service: TokenServicing
     
@@ -19,12 +20,14 @@ public final class CustomAuthSession: NSObject, LoginSession {
     ///    - window: UIWindow with a root view controller where you wish to show the login dialog
     public convenience init(window: UIWindow) {
         self.init(window: window,
-                  service: TokenService(client: .init()))
+                  service: TokenService(client: .init()),
+                  nonce: UUID().uuidString)
     }
     
-    init(window: UIWindow, service: TokenServicing) {
+    init(window: UIWindow, service: TokenServicing, nonce: String) {
         self.context = window
         self.service = service
+        self.nonce = nonce
     }
     
     /// Shows the login dialog
@@ -44,6 +47,7 @@ public final class CustomAuthSession: NSObject, LoginSession {
             .init(name: "state", value: self.state),
             .init(name: "redirect_uri", value: configuration.redirectURI),
             .init(name: "vtr", value: configuration.viewThroughRate),
+            .init(name: "nonce", value: nonce),
             .init(name: "ui_locales", value: configuration.locale.rawValue)
         ]
         

--- a/Sources/Authentication/Custom/CustomAuthSession.swift
+++ b/Sources/Authentication/Custom/CustomAuthSession.swift
@@ -44,7 +44,6 @@ public final class CustomAuthSession: NSObject, LoginSession {
             .init(name: "state", value: self.state),
             .init(name: "redirect_uri", value: configuration.redirectURI),
             .init(name: "vtr", value: configuration.viewThroughRate),
-            .init(name: "nonce", value: configuration.nonce),
             .init(name: "ui_locales", value: configuration.locale.rawValue)
         ]
         

--- a/Sources/Authentication/LoginSessionConfiguration.swift
+++ b/Sources/Authentication/LoginSessionConfiguration.swift
@@ -12,7 +12,6 @@ public struct LoginSessionConfiguration {
     
     public let redirectURI: String
     
-    public let nonce: String
     public let viewThroughRate: String
     public let locale: UILocale
     
@@ -39,7 +38,6 @@ public struct LoginSessionConfiguration {
                 clientID: String,
                 prefersEphemeralWebSession: Bool = true,
                 redirectURI: String,
-                nonce: String = UUID().uuidString,
                 viewThroughRate: String = "[Cl.Cm.P0]",
                 locale: UILocale = .en) {
         self.authorizationEndpoint = authorizationEndpoint
@@ -49,7 +47,6 @@ public struct LoginSessionConfiguration {
         self.clientID = clientID
         self.prefersEphemeralWebSession = prefersEphemeralWebSession
         self.redirectURI = redirectURI
-        self.nonce = nonce
         self.viewThroughRate = viewThroughRate
         self.locale = locale
     }

--- a/Tests/AuthenticationTests/AppAuthSessionTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionTests.swift
@@ -75,7 +75,6 @@ extension LoginSessionConfiguration {
                                                 clientID: "1234",
                                                 prefersEphemeralWebSession: true,
                                                 redirectURI: "https://www.google.com",
-                                                nonce: "1234",
                                                 viewThroughRate: "1234",
                                                 locale: .en)
 }

--- a/Tests/AuthenticationTests/CustomAuthSessionTests.swift
+++ b/Tests/AuthenticationTests/CustomAuthSessionTests.swift
@@ -12,7 +12,7 @@ final class CustomAuthSessionTests: XCTestCase {
         window.rootViewController = vc
         window.makeKeyAndVisible()
         
-        sut = .init(window: window, service: MockTokenService())
+        sut = .init(window: window, service: MockTokenService(), nonce: UUID().uuidString)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
+++ b/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
@@ -14,7 +14,6 @@ final class LoginSessionConfigurationTests: XCTestCase {
                                         clientID: "1234",
                                         prefersEphemeralWebSession: true,
                                         redirectURI: "https://www.google.com/redirect",
-                                        nonce: "1234",
                                         viewThroughRate: "1",
                                         locale: .en)
     }
@@ -53,10 +52,6 @@ extension LoginSessionConfigurationTests {
     
     func testRedirectURI() {
         XCTAssertEqual(sut.redirectURI, "https://www.google.com/redirect")
-    }
-    
-    func testNonce() {
-        XCTAssertEqual(sut.nonce, "1234")
     }
     
     func testViewThroughRate() {


### PR DESCRIPTION
# DCMAW-7207: iOS | Initiate login (build)

The `OIDAuthorizationRequest` type from the AppAuth package creates it's own `nonce` as part of the additionalParameters, which when we add our own as part of the `LoginSessionConfiguration` object creates an error on the back end.
This PR removes the nonce from our `LoginSessionConfiguration` type and amends the tests as part of the package

# Checklist

## Before raising your pull request:
- [ ] Update the documentation to reflect your changes
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
