### PR TITLE
fix!: amending default value for vtr and property name

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Handles creating the `config` found in `LoginSession`. It requires the following
   let redirectURI: String
    
   let nonce: String
-  let viewThroughRate: String
+  let vectorsOfTrust: String
   let locale: UILocale
 ```
 
@@ -105,7 +105,7 @@ let configuration = LoginSessionConfiguration(authorizationEndpoint: url,
                                               prefersEphemeralWebSession: true,
                                               redirectURI: "someRedirectURI",
                                               nonce: "someNonce",
-                                              viewThroughRate: "someThroughRate",
+                                              vectorsOfTrust: "someVectorOfTrust",
                                               locale: .en)
                                               
 session.present(configuration: configuration)

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -50,7 +50,7 @@ public final class AppAuthSession: LoginSession {
             redirectURL: URL(string: configuration.redirectURI)!,
             responseType: OIDResponseTypeCode,
             additionalParameters: [
-                "vtr": configuration.viewThroughRate,
+                "vtr": configuration.vectorsOfTrust,
                 "ui_locales": configuration.locale.rawValue
             ]
         )

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -50,7 +50,7 @@ public final class AppAuthSession: LoginSession {
             redirectURL: URL(string: configuration.redirectURI)!,
             responseType: OIDResponseTypeCode,
             additionalParameters: [
-                "vtr": configuration.vectorsOfTrust,
+                "vtr": configuration.vectorsOfTrust.description,
                 "ui_locales": configuration.locale.rawValue
             ]
         )

--- a/Sources/Authentication/Custom/CustomAuthSession.swift
+++ b/Sources/Authentication/Custom/CustomAuthSession.swift
@@ -46,7 +46,7 @@ public final class CustomAuthSession: NSObject, LoginSession {
             .init(name: "client_id", value: configuration.clientID),
             .init(name: "state", value: self.state),
             .init(name: "redirect_uri", value: configuration.redirectURI),
-            .init(name: "vtr", value: configuration.vectorsOfTrust),
+            .init(name: "vtr", value: configuration.vectorsOfTrust.description),
             .init(name: "nonce", value: nonce),
             .init(name: "ui_locales", value: configuration.locale.rawValue)
         ]

--- a/Sources/Authentication/Custom/CustomAuthSession.swift
+++ b/Sources/Authentication/Custom/CustomAuthSession.swift
@@ -46,7 +46,7 @@ public final class CustomAuthSession: NSObject, LoginSession {
             .init(name: "client_id", value: configuration.clientID),
             .init(name: "state", value: self.state),
             .init(name: "redirect_uri", value: configuration.redirectURI),
-            .init(name: "vtr", value: configuration.viewThroughRate),
+            .init(name: "vtr", value: configuration.vectorsOfTrust),
             .init(name: "nonce", value: nonce),
             .init(name: "ui_locales", value: configuration.locale.rawValue)
         ]

--- a/Sources/Authentication/LoginSessionConfiguration.swift
+++ b/Sources/Authentication/LoginSessionConfiguration.swift
@@ -12,7 +12,7 @@ public struct LoginSessionConfiguration {
     
     public let redirectURI: String
     
-    public let viewThroughRate: String
+    public let vectorsOfTrust: String
     public let locale: UILocale
     
     public enum ResponseType: String {
@@ -38,7 +38,7 @@ public struct LoginSessionConfiguration {
                 clientID: String,
                 prefersEphemeralWebSession: Bool = true,
                 redirectURI: String,
-                viewThroughRate: String = "[\"Cl.Cm.P0\"]",
+                vectorsOfTrust: String = "[\"Cl.Cm.P0\"]",
                 locale: UILocale = .en) {
         self.authorizationEndpoint = authorizationEndpoint
         self.tokenEndpoint = tokenEndpoint
@@ -47,7 +47,7 @@ public struct LoginSessionConfiguration {
         self.clientID = clientID
         self.prefersEphemeralWebSession = prefersEphemeralWebSession
         self.redirectURI = redirectURI
-        self.viewThroughRate = viewThroughRate
+        self.vectorsOfTrust = vectorsOfTrust
         self.locale = locale
     }
 }

--- a/Sources/Authentication/LoginSessionConfiguration.swift
+++ b/Sources/Authentication/LoginSessionConfiguration.swift
@@ -38,7 +38,7 @@ public struct LoginSessionConfiguration {
                 clientID: String,
                 prefersEphemeralWebSession: Bool = true,
                 redirectURI: String,
-                viewThroughRate: String = "[Cl.Cm.P0]",
+                viewThroughRate: String = "[\"Cl.Cm.P0\"]",
                 locale: UILocale = .en) {
         self.authorizationEndpoint = authorizationEndpoint
         self.tokenEndpoint = tokenEndpoint

--- a/Sources/Authentication/LoginSessionConfiguration.swift
+++ b/Sources/Authentication/LoginSessionConfiguration.swift
@@ -12,7 +12,7 @@ public struct LoginSessionConfiguration {
     
     public let redirectURI: String
     
-    public let vectorsOfTrust: String
+    public let vectorsOfTrust: [String]
     public let locale: UILocale
     
     public enum ResponseType: String {
@@ -38,7 +38,7 @@ public struct LoginSessionConfiguration {
                 clientID: String,
                 prefersEphemeralWebSession: Bool = true,
                 redirectURI: String,
-                vectorsOfTrust: String = "[\"Cl.Cm.P0\"]",
+                vectorsOfTrust: [String] = ["Cl.Cm.P0"],
                 locale: UILocale = .en) {
         self.authorizationEndpoint = authorizationEndpoint
         self.tokenEndpoint = tokenEndpoint

--- a/Tests/AuthenticationTests/AppAuthSessionTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionTests.swift
@@ -75,6 +75,6 @@ extension LoginSessionConfiguration {
                                                 clientID: "1234",
                                                 prefersEphemeralWebSession: true,
                                                 redirectURI: "https://www.google.com",
-                                                viewThroughRate: "1234",
+                                                vectorsOfTrust: "1234",
                                                 locale: .en)
 }

--- a/Tests/AuthenticationTests/AppAuthSessionTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionTests.swift
@@ -75,6 +75,6 @@ extension LoginSessionConfiguration {
                                                 clientID: "1234",
                                                 prefersEphemeralWebSession: true,
                                                 redirectURI: "https://www.google.com",
-                                                vectorsOfTrust: "1234",
+                                                vectorsOfTrust: ["1234"],
                                                 locale: .en)
 }

--- a/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
+++ b/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
@@ -14,7 +14,7 @@ final class LoginSessionConfigurationTests: XCTestCase {
                                         clientID: "1234",
                                         prefersEphemeralWebSession: true,
                                         redirectURI: "https://www.google.com/redirect",
-                                        vectorsOfTrust: "1",
+                                        vectorsOfTrust: ["1"],
                                         locale: .en)
     }
     
@@ -55,7 +55,7 @@ extension LoginSessionConfigurationTests {
     }
     
     func testViewThroughRate() {
-        XCTAssertEqual(sut.vectorsOfTrust, "1")
+        XCTAssertEqual(sut.vectorsOfTrust, ["1"])
     }
     
     func testLocale() {
@@ -70,6 +70,6 @@ extension LoginSessionConfigurationTests {
         XCTAssertEqual(sut.responseType, .code)
         XCTAssertEqual(sut.scopes, [.openid, .email, .phone, .offline_access])
         XCTAssertTrue(sut.prefersEphemeralWebSession)
-        XCTAssertEqual(sut.vectorsOfTrust, "[\"Cl.Cm.P0\"]")
+        XCTAssertEqual(sut.vectorsOfTrust, ["Cl.Cm.P0"])
     }
 }

--- a/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
+++ b/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
@@ -54,7 +54,7 @@ extension LoginSessionConfigurationTests {
         XCTAssertEqual(sut.redirectURI, "https://www.google.com/redirect")
     }
     
-    func testViewThroughRate() {
+    func testVectorsOfTrust() {
         XCTAssertEqual(sut.vectorsOfTrust, ["1"])
     }
     
@@ -71,5 +71,6 @@ extension LoginSessionConfigurationTests {
         XCTAssertEqual(sut.scopes, [.openid, .email, .phone, .offline_access])
         XCTAssertTrue(sut.prefersEphemeralWebSession)
         XCTAssertEqual(sut.vectorsOfTrust, ["Cl.Cm.P0"])
+        XCTAssertEqual(sut.vectorsOfTrust.description, "[\"Cl.Cm.P0\"]")
     }
 }

--- a/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
+++ b/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
@@ -70,6 +70,6 @@ extension LoginSessionConfigurationTests {
         XCTAssertEqual(sut.responseType, .code)
         XCTAssertEqual(sut.scopes, [.openid, .email, .phone, .offline_access])
         XCTAssertTrue(sut.prefersEphemeralWebSession)
-        XCTAssertEqual(sut.viewThroughRate, "[Cl.Cm.P0]")
+        XCTAssertEqual(sut.viewThroughRate, "[\"Cl.Cm.P0\"]")
     }
 }

--- a/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
+++ b/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
@@ -14,7 +14,7 @@ final class LoginSessionConfigurationTests: XCTestCase {
                                         clientID: "1234",
                                         prefersEphemeralWebSession: true,
                                         redirectURI: "https://www.google.com/redirect",
-                                        viewThroughRate: "1",
+                                        vectorsOfTrust: "1",
                                         locale: .en)
     }
     
@@ -55,7 +55,7 @@ extension LoginSessionConfigurationTests {
     }
     
     func testViewThroughRate() {
-        XCTAssertEqual(sut.viewThroughRate, "1")
+        XCTAssertEqual(sut.vectorsOfTrust, "1")
     }
     
     func testLocale() {
@@ -70,6 +70,6 @@ extension LoginSessionConfigurationTests {
         XCTAssertEqual(sut.responseType, .code)
         XCTAssertEqual(sut.scopes, [.openid, .email, .phone, .offline_access])
         XCTAssertTrue(sut.prefersEphemeralWebSession)
-        XCTAssertEqual(sut.viewThroughRate, "[\"Cl.Cm.P0\"]")
+        XCTAssertEqual(sut.vectorsOfTrust, "[\"Cl.Cm.P0\"]")
     }
 }


### PR DESCRIPTION
# DCMAW-7207: iOS Initiate login (build) also factoring in DCMAW-7303: iOS | Correct naming of vtr parameter in di-mobile-ios-authentication package

The default value for our viewThroughRate property wasn't formed correctly, this PR addresses that. Furthermore the property being named viewThroughRate is incorrect and should be vectorsOfTrust which this PR address as well.

# Checklist

## Before raising your pull request:
- [ ] Update the documentation to reflect your changes
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
